### PR TITLE
added some scripts to backup and set Virtual Machine arguments

### DIFF
--- a/ant/configuration-ant-defs.xml
+++ b/ant/configuration-ant-defs.xml
@@ -61,5 +61,12 @@
 		arguments="${basedir}/conf/"
 		fileName="${basedir}\wlst\classpathSetConfig.py"/>
 	</target>
+
+	<target name="bkpVMArgsConfig" depends="configureOptions" if="do.backup">
+		<wlst debug="false" failOnError="true" 
+	   	properties="${basedir}\conf\${configEnv}_wlst.properties"
+		arguments="${basedir}/conf/"
+		fileName="${basedir}\wlst\vmArgsBkpConfig.py"/>
+	</target>
 	
 </project>

--- a/ant/configuration-ant-defs.xml
+++ b/ant/configuration-ant-defs.xml
@@ -69,4 +69,11 @@
 		fileName="${basedir}\wlst\vmArgsBkpConfig.py"/>
 	</target>
 	
+	<target name="createVMArgsConfig" depends="bkpVMArgsConfig" unless="do.action">
+		<wlst debug="false" failOnError="true" 
+	   	properties="${basedir}\conf\${configEnv}_wlst.properties"
+		arguments="${basedir}/conf/"
+		fileName="${basedir}\wlst\vmArgsSetConfig.py"/>
+	</target>
+	
 </project>

--- a/cmds/createClasspathConfig.cmd
+++ b/cmds/createClasspathConfig.cmd
@@ -1,5 +1,5 @@
 @rem *************************************************************************
-@rem This script is used to set up the JDBC properties to DFSL   
+@rem This script is used to set up the Classpath properties BASED ON THE CONF FILES   
 @rem *************************************************************************
 @echo At the first time configure the Classapath 
 CALL "%WORKSPACE%\wlst\setWLSEnvironment.cmd"

--- a/cmds/createManagedServerConfig.cmd
+++ b/cmds/createManagedServerConfig.cmd
@@ -1,5 +1,5 @@
 @rem *************************************************************************
-@rem This script is used to set up the Managed Servers properties to DFSL   
+@rem This script is used to set up the Managed Servers BASED ON THE CONF FILES   
 @rem *************************************************************************
 @echo At the first time configure the Classapath 
 CALL "%WORKSPACE%\cmds\setWLSEnvironment.cmd"

--- a/cmds/createVMArgsConfig.cmd
+++ b/cmds/createVMArgsConfig.cmd
@@ -1,0 +1,12 @@
+@rem ******************************************************************************
+@rem This script is used to set up the VMARGS properties BASED ON THE CONF FILES   
+@rem ******************************************************************************
+@echo At the first time configure the Classapath 
+CALL "%WORKSPACE%\wlst\setWLSEnvironment.cmd"
+@echo off
+@echo After the classpath configuration call the ANT task.
+@echo Execute the Ant Task
+ant createVMArgsConfig -buildfile "%WORKSPACE%\build.xml" -Dbuild.env=server -DconfigEnv=%1 -DconfigAction=%2
+@echo Ant task executed
+
+:finish

--- a/wlst/vmArgsBkpConfig.py
+++ b/wlst/vmArgsBkpConfig.py
@@ -1,0 +1,91 @@
+#### Utils Functions#################
+
+## Added to get the BeanAlreadyExistsException 
+from weblogic.descriptor import BeanAlreadyExistsException 
+
+def addPropertySeparator(nameToAdd):
+    separator = "_"
+    return nameToAdd + separator
+
+def connectToWebLogic():
+    print '################################################################'
+    print '    Trying to connect the Server: '+ wlHost + ':' + wlPort
+    print '################################################################'
+    ### Connect to the Administration Server
+    try:
+        connect(wlUsername,wlPassword,'t3://'+wlHost+':'+wlPort)
+        return true
+    except Exception, e:
+        print "(-01) Error while trying to connect in: t3://"+wlHost+":"+wlPort+". Please verify the parameters."
+ 
+def disconnectFromWebLogic():
+    disconnect() 
+    exit()
+    
+def startToEdit():
+    edit()
+    startEdit()
+    cd('/')            
+       
+def savePreviousArguments(managedServerName):
+    from java.io import File
+    from java.io import FileOutputStream
+    from java.util import Properties
+    from java.util import Date
+    from java.text import SimpleDateFormat
+    
+    import string
+    startToEdit()
+    # parameter on the wsdl ant task call
+    fileLocation = sys.argv[1].replace("\\","/")
+    print "The backup file location is"
+    print fileLocation
+    try:
+        dateFormat = SimpleDateFormat('_d_MMM_yyyy_HH_mm_ss')
+        date = Date()
+        formattedDate = dateFormat.format(date)
+        print formattedDate
+    except:
+        print "The date cannot be created/formatted"
+        
+    try:    
+        propsFile = File(fileLocation+ managedServerName + formattedDate+"_config.bkp");
+        print propsFile.exists()
+        if(propsFile.exists() == 0):
+            propsFile.createNewFile()
+    except:
+        print "The file cannot be created on:"
+        print propsFile.getAbsoluteFile()
+        dumpStack()     
+        
+    previousProperties = Properties()
+    print '===> Saving the  previous arguments - ' + managedServerName
+    cd('/Servers/'+managedServerName)
+    print "Getting the VMArgs"
+    vmArgs = cmo.getServerStart().getArguments()
+    print vmArgs
+    if vmArgs == None:
+        vmArgs = ""
+    previousProperties.setProperty("vmArgs", vmArgs)
+    print "Saving Arguments to file"
+    previousProperties.store(FileOutputStream(propsFile),None)
+    print '===> Saved arguments! Please verify the file on:'+ fileLocation + "in" + managedServerName 
+        
+def backupPreviousVMArguments(managedServersToCreate):
+    import string
+    managedServersList = string.split(managedServersToCreate,"|")
+    if len(managedServersList)> 0 and managedServersList[0] != '' :
+        for managedServerName in managedServersList:
+            try:
+                print "Managed Server Name: " + managedServerName
+                savePreviousArguments(managedServerName.strip())
+            except Exception, e:
+               print e
+               dumpStack()
+    else:
+        print "Please verify the value of property managedServersToCreate on WLST configuration file"
+                    
+connStatus = connectToWebLogic()
+if connStatus != None:
+    backupPreviousVMArguments(managedServersToCreate)
+    disconnectFromWebLogic()

--- a/wlst/vmArgsSetConfig.py
+++ b/wlst/vmArgsSetConfig.py
@@ -1,0 +1,70 @@
+#### Utils Functions#################
+
+## Added to get the BeanAlreadyExistsException 
+from weblogic.descriptor import BeanAlreadyExistsException 
+
+def addPropertySeparator(nameToAdd):
+    separator = "_"
+    return nameToAdd + separator
+
+def connectToWebLogic():
+    print '################################################################'
+    print '    Trying to connect the Server: '+ wlHost + ':' + wlPort
+    print '################################################################'
+    ### Connect to the Administration Server
+    try:
+        connect(wlUsername,wlPassword,'t3://'+wlHost+':'+wlPort)
+        return true
+    except Exception, e:
+        print "(-01) Error while trying to connect in: t3://"+wlHost+":"+wlPort+". Please verify the parameters."
+ 
+def disconnectFromWebLogic():
+    disconnect() 
+    exit()
+    
+def startToEdit():
+    edit()
+    startEdit()
+    cd('/')            
+    
+def saveActivate():
+### Activate the changes
+    try:
+        save()
+        activate()        
+    except Exception, e2:
+        print "(-02) Error while trying to save and/or activate. Please verify the parameters for that and the error type below."
+        print "Error Type:",sys.exc_info()[0]
+        #print sys.exc_info()[0], sys.exc_info()[1]     
+        
+def setVMArguments(managedServerName):
+    import string    
+    startToEdit()
+    print '===> Add arguments to  - ' + managedServerName
+    serverArguments      = eval(addPropertySeparator(managedServerName)+"serverArguments").strip()
+    startEdit()
+    cd('/Servers/'+managedServerName+'/ServerStart/'+managedServerName)    
+    cmo.setArguments(serverArguments)
+    cd('/Servers/'+managedServerName+'/SSL/'+managedServerName)
+       
+def configureVMArguments(managedServersToCreate):
+    import string
+    managedServersList = string.split(managedServersToCreate,"|")
+    if len(managedServersList)> 0 and managedServersList[0] != '' :
+        for managedServerName in managedServersList:
+            try:
+                print "Managed Server Name: " + managedServerName
+                print "Start to create"
+                setVMArguments(managedServerName.strip())
+                print "Save and Activate the changes."    
+                saveActivate()
+            except Exception, e:
+               print e
+               dumpStack()
+    else:
+        print "Please verify the value of property managedServersToCreate on WLST configuration file"
+            
+connStatus = connectToWebLogic()
+if connStatus != None:    
+    configureVMArguments(managedServersToCreate)
+    disconnectFromWebLogic()


### PR DESCRIPTION
After have configured the managed server, and its classpath is time to have its VM arguments configured based on .properties definition.

To do so you can go ahead now, and:
1. Run the ant target createClasspathConfig; it'll backup configurations into fileLocation+ managedServerName + formattedDate+"_config.bkp";
